### PR TITLE
Remove instance from token wrapper

### DIFF
--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -507,7 +507,11 @@ impl<T: Config> Pallet<T> {
 
 				detail.asset_type = asset_type.clone();
 
-				Self::deposit_event(Event::Updated(pool_asset_id.clone(), detail.name.clone(), asset_type));
+				Self::deposit_event(Event::Updated {
+					asset_id: pool_asset_id.clone(),
+					name: detail.name.clone(),
+					asset_type,
+				});
 
 				Ok(pool_asset_id)
 			},
@@ -539,7 +543,11 @@ impl<T: Config> Pallet<T> {
 
 				detail.asset_type = asset_type.clone();
 
-				Self::deposit_event(Event::Updated(pool_asset_id.clone(), detail.name.clone(), asset_type));
+				Self::deposit_event(Event::Updated {
+					asset_id: pool_asset_id.clone(),
+					name: detail.name.clone(),
+					asset_type,
+				});
 
 				Ok(pool_asset_id)
 			},

--- a/pallets/token-wrapper/src/tests.rs
+++ b/pallets/token-wrapper/src/tests.rs
@@ -323,3 +323,53 @@ fn should_unwrap_when_liquidity_exists_for_selected_asset() {
 		assert_eq!(TokenWrapper::get_balance(second_token_id, &recipient), 50000);
 	})
 }
+
+#[test]
+fn should_not_wrap_invalid_amount() {
+	new_test_ext().execute_with(|| {
+		let existential_balance: u32 = 1000;
+		let first_token_id = AssetRegistry::register_asset(
+			b"shib".to_vec().try_into().unwrap(),
+			AssetType::Token,
+			existential_balance.into(),
+		)
+		.unwrap();
+		let second_token_id = AssetRegistry::register_asset(
+			b"doge".to_vec().try_into().unwrap(),
+			AssetType::Token,
+			existential_balance.into(),
+		)
+		.unwrap();
+
+		let pool_share_id = AssetRegistry::register_asset(
+			b"meme".to_vec().try_into().unwrap(),
+			AssetType::PoolShare(vec![second_token_id, first_token_id]),
+			existential_balance.into(),
+		)
+		.unwrap();
+
+		let recipient: u64 = 1;
+
+		let balance: i128 = 100000;
+
+		assert_ok!(Currencies::update_balance(
+			Origin::root(),
+			recipient,
+			first_token_id,
+			balance.into()
+		));
+
+		assert_ok!(TokenWrapper::set_wrapping_fee(Origin::root(), 5));
+
+		assert_err!(
+			TokenWrapper::wrap(
+				Origin::signed(recipient),
+				first_token_id,
+				pool_share_id,
+				0 as u128,
+				recipient
+			),
+			crate::Error::<Test>::InvalidAmount
+		);
+	})
+}


### PR DESCRIPTION
Updated new functions  added in token-wrapper PR in pallet-asset-registry to use updated event types, this fixes the build error in pallet asset registry