### PR TITLE
Add mixer + asset registry config to chain spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,13 +1,13 @@
 use arkworks_gadgets::prelude::ark_bn254::Bn254;
 use arkworks_utils::{
 	poseidon::PoseidonParameters,
-	utils::common::{setup_params_x3_5, setup_params_x5_3, setup_params_x5_5, Curve},
+	utils::common::{setup_params_x5_3, setup_params_x5_5, Curve},
 };
 use common::{AccountId, AuraId, Signature};
 use darkwebb_primitives::Balance;
 use darkwebb_runtime::{
-	wasm_binary_unwrap, AuraConfig, BalancesConfig, CouncilConfig, GenesisConfig, HasherBls381Config,
-	HasherBn254Config, MerkleTreeBls381Config, MerkleTreeBn254Config, ParachainStakingConfig, SudoConfig, SystemConfig,
+	wasm_binary_unwrap, AssetRegistryConfig, AuraConfig, BalancesConfig, CouncilConfig, GenesisConfig, HasherBls381Config,
+	HasherBn254Config, MerkleTreeBls381Config, MerkleTreeBn254Config, MixerBn254Config, ParachainStakingConfig, SudoConfig, SystemConfig,
 	VerifierBls381Config, VerifierBn254Config, KUNITS, UNITS,
 };
 
@@ -277,6 +277,11 @@ fn testnet_genesis(
 			code: wasm_binary_unwrap().to_vec(),
 			changes_trie_config: Default::default(),
 		},
+		asset_registry: AssetRegistryConfig {
+			asset_names: vec![],
+			native_asset_name: b"WEBB".to_vec(),
+			native_existential_deposit: darkwebb_runtime::constants::currency::EXISTENTIAL_DEPOSIT,
+		},
 		balances: darkwebb_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect(),
 		},
@@ -324,6 +329,13 @@ fn testnet_genesis(
 		merkle_tree_bls_381: MerkleTreeBls381Config {
 			phantom: Default::default(),
 			default_hashes: None,
+		},
+		mixer_bn_254: MixerBn254Config {
+			mixers: vec![
+				(0, 10 * UNITS),
+				(0, 100 * UNITS),
+				(0, 1000 * UNITS),
+			],
 		},
 		council: CouncilConfig::default(),
 		treasury: Default::default(),

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -71,6 +71,7 @@ use sp_runtime::traits::AccountIdConversion;
 use sp_std::prelude::*;
 use types::*;
 pub use weights::WeightInfo;
+use orml_traits::currency::transactional;
 
 /// Type alias for the orml_traits::MultiCurrency::Balance type
 pub type BalanceOf<T, I> =
@@ -194,6 +195,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[transactional]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::deposit())]
 		pub fn deposit(origin: OriginFor<T>, tree_id: T::TreeId, leaf: T::Element) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
@@ -204,6 +206,7 @@ pub mod pallet {
 		/// Same as [Self::deposit] but with another call to update the linked
 		/// anchors cross-chain (if any).
 		// FIXME: update the weight here
+		#[transactional]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::deposit())]
 		pub fn deposit_and_update_linked_anchors(
 			origin: OriginFor<T>,
@@ -221,6 +224,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[transactional]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::withdraw())]
 		pub fn withdraw(
 			origin: OriginFor<T>,

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -159,11 +159,12 @@ pub mod pallet {
 		fn default() -> Self {
 			GenesisConfig::<T> {
 				asset_names: vec![],
-				native_asset_name: b"BSX".to_vec(),
+				native_asset_name: b"WEBB".to_vec(),
 				native_existential_deposit: Default::default(),
 			}
 		}
 	}
+
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {

--- a/pallets/asset-registry/src/tests.rs
+++ b/pallets/asset-registry/src/tests.rs
@@ -164,8 +164,8 @@ fn genesis_config_works() {
 			let native: BoundedVec<u8, <Test as crate::Config>::StringLimit> = b"NATIVE".to_vec().try_into().unwrap();
 			assert_eq!(AssetRegistryPallet::asset_ids(native), None);
 
-			let bsx: BoundedVec<u8, <Test as crate::Config>::StringLimit> = b"BSX".to_vec().try_into().unwrap();
-			assert_eq!(AssetRegistryPallet::asset_ids(bsx).unwrap(), 0u32);
+			let webb: BoundedVec<u8, <Test as crate::Config>::StringLimit> = b"WEBB".to_vec().try_into().unwrap();
+			assert_eq!(AssetRegistryPallet::asset_ids(webb).unwrap(), 0u32);
 
 			let one: BoundedVec<u8, <Test as crate::Config>::StringLimit> = b"ONE".to_vec().try_into().unwrap();
 			assert_eq!(AssetRegistryPallet::asset_ids(one.clone()).unwrap(), 1u32);

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -173,6 +173,43 @@ pub mod pallet {
 		NoMixerFound,
 	}
 
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config<I>, I: 'static = ()> {
+		// (asset_id, deposit_size)
+		pub mixers: Vec<(CurrencyIdOf<T, I>, BalanceOf<T, I>)>,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config<I>, I: 'static> Default for GenesisConfig<T, I> {
+		fn default() -> Self {
+			GenesisConfig::<T, I> {
+				mixers: vec![],
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config<I>, I: 'static> GenesisBuild<T, I> for GenesisConfig<T, I> {
+		fn build(&self) {
+			self.mixers.iter().for_each(|(asset_id, deposit_size)| {
+				let _ = <Pallet::<T, I> as MixerInterface<
+					T::AccountId,
+					BalanceOf<T, I>,
+					CurrencyIdOf<T, I>,
+					T::TreeId,
+					T::Element,
+				>>::create(
+					T::AccountId::default(),
+					deposit_size.clone(),
+					30,
+					asset_id.clone(),
+				)
+				.map_err(|_| panic!("Failed to create mixer"));
+			})
+		}
+	}
+
 	#[pallet::hooks]
 	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
 

--- a/pallets/mixer/src/lib.rs
+++ b/pallets/mixer/src/lib.rs
@@ -77,6 +77,7 @@ use frame_support::{
 };
 use orml_traits::MultiCurrency;
 use sp_std::prelude::*;
+use orml_traits::currency::transactional;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -259,6 +260,7 @@ pub mod pallet {
 			})
 		}
 
+		#[transactional]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::deposit())]
 		pub fn deposit(origin: OriginFor<T>, tree_id: T::TreeId, leaf: T::Element) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
@@ -266,6 +268,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[transactional]
 		#[pallet::weight(<T as Config<I>>::WeightInfo::withdraw())]
 		pub fn withdraw(
 			origin: OriginFor<T>,

--- a/pallets/vanchor/src/lib.rs
+++ b/pallets/vanchor/src/lib.rs
@@ -72,6 +72,8 @@ use orml_traits::{
 	arithmetic::{Signed, Zero},
 	MultiCurrency, MultiCurrencyExtended,
 };
+use orml_traits::currency::transactional;
+
 use sp_runtime::traits::AccountIdConversion;
 use sp_std::{
 	convert::{TryFrom, TryInto},
@@ -218,6 +220,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		#[transactional]
 		#[pallet::weight(0)] // TODO: Fix after benchmarks
 		pub fn transact(
 			origin: OriginFor<T>,

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -20,7 +20,7 @@ pub mod currency {
 	pub const EXISTENTIAL_DEPOSIT: Balance = CENTS / 10;
 
 	pub const UNITS: Balance = 1_000_000_000_000;
-	pub const KUNITS: Balance = 1_000_000_000_000_000;
+	pub const KUNITS: Balance = UNITS * 1000;
 	pub const DOLLARS: Balance = UNITS;
 	pub const CENTS: Balance = UNITS / 30_000;
 	pub const GRAND: Balance = CENTS * 100_000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1059,7 +1059,7 @@ construct_runtime!(
 		HasherBn254: pallet_hasher::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
 		HasherBls381: pallet_hasher::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>},
 
-		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>},
+		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>, Config<T>},
 		Currencies: orml_currencies::{Pallet, Call, Event<T>},
 		Tokens: orml_tokens::{Pallet, Storage, Call, Event<T>},
 		TokenWrapper: pallet_token_wrapper::{Pallet, Storage, Call, Event<T>},
@@ -1077,7 +1077,7 @@ construct_runtime!(
 		LinkableTreeBls381: pallet_linkable_tree::<Instance2>::{Pallet, Call, Storage, Event<T>},
 
 		// Mixer
-		MixerBn254: pallet_mixer::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		MixerBn254: pallet_mixer::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
 		MixerBls381: pallet_mixer::<Instance2>::{Pallet, Call, Storage, Event<T>},
 
 		// Anchor

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -5,7 +5,7 @@ use darkwebb_runtime::{
 	constants::currency::*, wasm_binary_unwrap, AuthorityDiscoveryConfig, BabeConfig, Block, CouncilConfig,
 	DemocracyConfig, ElectionsConfig, GenesisConfig, GrandpaConfig, HasherBls381Config, HasherBn254Config,
 	ImOnlineConfig, IndicesConfig, MerkleTreeBls381Config, MerkleTreeBn254Config, SessionConfig, StakerStatus,
-	StakingConfig, SudoConfig, VerifierBls381Config, VerifierBn254Config,
+	StakingConfig, SudoConfig, VerifierBls381Config, VerifierBn254Config, AssetRegistryConfig, MixerBn254Config,
 };
 use itertools::Itertools;
 use sc_chain_spec::ChainSpecExtension;
@@ -231,6 +231,11 @@ fn testnet_genesis(
 			code: wasm_binary_unwrap().to_vec(),
 			changes_trie_config: Default::default(),
 		},
+		asset_registry: AssetRegistryConfig {
+			asset_names: vec![],
+			native_asset_name: b"WEBB".to_vec(),
+			native_existential_deposit: darkwebb_runtime::constants::currency::EXISTENTIAL_DEPOSIT,
+		},
 		balances: darkwebb_runtime::BalancesConfig {
 			balances: unique.iter().cloned().map(|k| (k, ENDOWMENT)).collect(),
 		},
@@ -300,6 +305,13 @@ fn testnet_genesis(
 		merkle_tree_bls_381: MerkleTreeBls381Config {
 			phantom: Default::default(),
 			default_hashes: None,
+		},
+		mixer_bn_254: MixerBn254Config {
+			mixers: vec![
+				(0, 10 * UNITS),
+				(0, 100 * UNITS),
+				(0, 1000 * UNITS),
+			],
 		},
 	}
 }

--- a/standalone/runtime/src/constants.rs
+++ b/standalone/runtime/src/constants.rs
@@ -20,6 +20,7 @@ pub mod currency {
 	pub const EXISTENTIAL_DEPOSIT: Balance = CENTS / 10;
 
 	pub const UNITS: Balance = 1_000_000_000_000;
+	pub const KUNITS: Balance = UNITS * 1000;
 	pub const DOLLARS: Balance = UNITS;
 	pub const CENTS: Balance = UNITS / 30_000;
 	pub const GRAND: Balance = CENTS * 100_000;

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1287,7 +1287,7 @@ construct_runtime!(
 		HasherBn254: pallet_hasher::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
 		HasherBls381: pallet_hasher::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>},
 
-		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>},
+		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>, Config<T>},
 		Currencies: orml_currencies::{Pallet, Call, Event<T>},
 		Tokens: orml_tokens::{Pallet, Storage, Call, Event<T>},
 		TokenWrapper: pallet_token_wrapper::{Pallet, Storage, Call, Event<T>},
@@ -1305,7 +1305,7 @@ construct_runtime!(
 		LinkableTreeBls381: pallet_linkable_tree::<Instance2>::{Pallet, Call, Storage, Event<T>},
 
 		// Mixer
-		MixerBn254: pallet_mixer::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		MixerBn254: pallet_mixer::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>},
 		MixerBls381: pallet_mixer::<Instance2>::{Pallet, Call, Storage, Event<T>},
 
 		// Anchor


### PR DESCRIPTION
@AhmedKorim this adds mixers on chain init and assigns proper deposit size to prevent the existential balance error. We still aren't handling the note generation correct because the UI doesn't handle the # of units for Substrate properly.