### PR TITLE
Remove unused secp256k1 dependency from pallet-signature-bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,7 +6635,6 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "secp256k1",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -10439,24 +10438,6 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7883017d5b21f011ef8040ea9c6c7ac90834c0df26a69e4c0b06276151f125"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/pallets/signature-bridge/Cargo.toml
+++ b/pallets/signature-bridge/Cargo.toml
@@ -29,7 +29,6 @@ pallet-balances = { default-features = false, git = "https://github.com/parityte
 frame-system-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
 
-secp256k1 = { version = "0.21.2", default-features = false }
 webb-primitives = { path = "../../primitives", default-features = false }
 hex-literal = "0.3.4"
 
@@ -45,7 +44,6 @@ std = [
 	"frame-system/std",
 	"pallet-balances/std",
 	"webb-primitives/std",
-	"secp256k1/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",


### PR DESCRIPTION
This dependency is causing build errors, and it doesn't appear to be used.