### PR TITLE
chore: adds/updates pallet documentation

### DIFF
--- a/pallets/anchor-handler/src/lib.rs
+++ b/pallets/anchor-handler/src/lib.rs
@@ -17,27 +17,28 @@
 
 //! # Anchor Handler Module
 //!
-//! A module for executing the creation or modification of anchors.
+//! A module for executing the creation and modification of anchors.
 //!
 //! ## Overview
 //!
 //! The anchor-handler module provides functionality for the following:
 //!
-//! * The creation of anchors
-//! * Updating existing anchors
+//! * The creation of anchors from proposals
+//! * Updating existing anchors from proposals
 //!
 //! ## Interface
 //!
 //! ### Permissioned Functions
 //!
-//! * `execute_anchor_create_proposal`: Creates an anchor from successfully voted on proposal.
+//! * `execute_anchor_create_proposal`: Creates an anchor from successfully voted on proposal. This
+//!   method requires the `origin` to be [T::BridgeOrigin].
 //! * `execute_anchor_update_proposal`: Adds/Updates an anchor from successfully voted on proposal.
+//!   This method requires the `origin` to be [T::BridgeOrigin].
 //!
 //! ## Related Modules
 //!
-//! * [`Anchor`](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/anchor/src/lib.rs)
-//! * [`Bridge`](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/bridge/src/lib.rs)
-//! * [`Signature-bridge`](https://github.com/webb-tools/protocol-substrate/tree/main/pallets/signature-bridge/src)
+//! * Anchor pallet
+//! * Linkable-tree pallet
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/anchor-handler/src/lib.rs
+++ b/pallets/anchor-handler/src/lib.rs
@@ -17,26 +17,27 @@
 
 //! # Anchor Handler Module
 //!
-//! Add description #TODO
+//! A module for executing the creation or modification of anchors.
 //!
 //! ## Overview
 //!
+//! The anchor-handler module provides functionality for the following:
 //!
-//! ### Terminology
-//!
-//! ### Goals
-//!
-//! The anchor handler system in Webb is designed to make the following
-//! possible:
-//!
-//! * Define.
+//! * The creation of anchors
+//! * Updating existing anchors
 //!
 //! ## Interface
 //!
+//! ### Permissioned Functions
+//!
+//! * `execute_anchor_create_proposal`: Creates an anchor from successfully voted on proposal.
+//! * `execute_anchor_update_proposal`: Adds/Updates an anchor from successfully voted on proposal.
+//!
 //! ## Related Modules
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * [`Anchor`](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/anchor/src/lib.rs)
+//! * [`Bridge`](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/bridge/src/lib.rs)
+//! * [`Signature-bridge`](https://github.com/webb-tools/protocol-substrate/tree/main/pallets/signature-bridge/src)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -29,18 +29,27 @@
 //!
 //! ### Terminology
 //!
-//! ### Goals
-//!
-//! The Anchor system in Webb is designed to make the following possible:
-//!
-//! * Define.
+//! * **Anchor**: Connected instances that contains an on-chain merkle tree and tracks a set of
+//!   connected __anchors__ across chains (through edges) in its local storage.
+//! * **Edge**: An edge is a directed connection or link between two anchors.
 //!
 //! ## Interface
 //!
+//! ### Permissioned Functions
+//!
+//! * `create`: Creates an anchor. This can be only called by the Root.
+//!
+//! ### Permissionless Functions
+//!
+//! * `deposit`: Inserts elements into on-chain merkle tree.
+//! * `deposit_and_update_linked_anchors`: Same as [Self::deposit] but with another call to update
+//!   the linked anchors cross-chain (if any).
+//! * `withdraw`: Withdraw requires a zero-knowledge proof of a unspent deposit in some anchors’
+//!   merkle tree on either this chain or a neighboring chain
+//!
 //! ## Related Modules
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * Linkable-tree pallet
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -23,44 +23,44 @@
 //!
 //! The bridge module provides functionality for the following:
 //!
-//! * Private, and public bridging of assets
+//! * Private bridging of assets
 //!
 //! ### Terminology
 //!
-//! * **Admin**: An account ID uniquely privileged to be able to set voting thresholds for
-//!   proposals, add additional chains for bridge transfers, set and remove resource ID's from the
-//!   resource mapping, as well as, add and remove relayers from the active set.
+//! * **Admin**: An account uniquely privileged to be able to set voting thresholds for proposals,
+//!   add additional chains for bridge transfers, set and remove resource ID's from the resource
+//!   mapping, as well as, add and remove relayers from the active set.
 //! * **Whitelist**: Explicitly enabled chains that can be used to bridge assets.
 //!
 //! ### Goals
 //!
 //! The bridge system in Webb is designed to make the following possible:
 //!
-//! * Bridge assets across a EVM and Substrate based chains
-//! * Manage state through voted proposals
+//! * Bridge assets across an EVM and Substrate based chains
 //! * Execute approved proposals and cancel rejected proposals
 //!
 //! ## Interface
 //!
 //! ### Permissioned Functions
 //!
-//! * `set_threshold`: Sets the vote threshold for proposals.
-//! * `set_resource`: Stores a method name on chain under an associated resource ID.
-//! * `remove_resource`: Removes a resource ID from the resource mapping.
-//! * `whitelist_chain`: Enables a chain ID as a source or destination for a bridge transfer.
-//! * `add_relayer`: Adds a new relayer to the relayer set.
-//! * `remove_relayer`: Removes an existing relayer from the set.
+//! * `set_threshold`: Sets the vote threshold for proposals. This method requires the `origin` to
+//!   be [T::AdminOrigin].
+//! * `set_resource`: Stores a method name on chain under an associated resource ID. This method
+//!   requires the `origin` to be [T::AdminOrigin].
+//! * `remove_resource`: Removes a resource ID from the resource mapping. This method requires the
+//!   `origin` to be [T::AdminOrigin].
+//! * `whitelist_chain`: Enables a chain ID as a source or destination for a bridge transfer. This
+//!   method requires the `origin` to be [T::AdminOrigin].
+//! * `add_relayer`: Adds a new relayer to the relayer set. This method requires the `origin` to be
+//!   [T::AdminOrigin].
+//! * `remove_relayer`: Removes an existing relayer from the set. This method requires the `origin`
+//!   to be [T::AdminOrigin].
 //!
 //! ### Permissionless Functions
 //!
 //! * `acknowledge_proposal`: Commits a vote in favour of the provided proposal.
 //! * `reject_proposal`: Commits a vote against a provided proposal.
 //! * `eval_vote_state`: Evaluate the state of a proposal given the current vote threshold.
-//!
-//! ## Related Modules
-//!
-//! * [`Relayers`](https://github.com/webb-tools/relayer)
-//! * [`SignatureBridge.sol`](https://github.com/webb-tools/protocol-solidity/blob/main/contracts/SignatureBridge.sol)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/bridge/src/lib.rs
+++ b/pallets/bridge/src/lib.rs
@@ -17,26 +17,50 @@
 
 //! # Bridge Module
 //!
-//! Add description #TODO
+//! A module for managing voting, resource, and relayer composition.
 //!
 //! ## Overview
 //!
+//! The bridge module provides functionality for the following:
+//!
+//! * Private, and public bridging of assets
 //!
 //! ### Terminology
 //!
+//! * **Admin**: An account ID uniquely privileged to be able to set voting thresholds for
+//!   proposals, add additional chains for bridge transfers, set and remove resource ID's from the
+//!   resource mapping, as well as, add and remove relayers from the active set.
+//! * **Whitelist**: Explicitly enabled chains that can be used to bridge assets.
+//!
 //! ### Goals
 //!
-//! The bridge system in Webb is designed to make the following
-//! possible:
+//! The bridge system in Webb is designed to make the following possible:
 //!
-//! * Define.
+//! * Bridge assets across a EVM and Substrate based chains
+//! * Manage state through voted proposals
+//! * Execute approved proposals and cancel rejected proposals
 //!
 //! ## Interface
 //!
+//! ### Permissioned Functions
+//!
+//! * `set_threshold`: Sets the vote threshold for proposals.
+//! * `set_resource`: Stores a method name on chain under an associated resource ID.
+//! * `remove_resource`: Removes a resource ID from the resource mapping.
+//! * `whitelist_chain`: Enables a chain ID as a source or destination for a bridge transfer.
+//! * `add_relayer`: Adds a new relayer to the relayer set.
+//! * `remove_relayer`: Removes an existing relayer from the set.
+//!
+//! ### Permissionless Functions
+//!
+//! * `acknowledge_proposal`: Commits a vote in favour of the provided proposal.
+//! * `reject_proposal`: Commits a vote against a provided proposal.
+//! * `eval_vote_state`: Evaluate the state of a proposal given the current vote threshold.
+//!
 //! ## Related Modules
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * [`Relayers`](https://github.com/webb-tools/relayer)
+//! * [`SignatureBridge.sol`](https://github.com/webb-tools/protocol-solidity/blob/main/contracts/SignatureBridge.sol)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/hasher/src/lib.rs
+++ b/pallets/hasher/src/lib.rs
@@ -34,21 +34,6 @@
 //! webb_primitives::hasher module.
 //!
 //! The supported dispatchable functions are documented in the [`Call`] enum.
-//!
-//! ### Terminology
-//!
-//! ### Goals
-//!
-//! The hasher system in Webb is designed to make the following possible:
-//!
-//! * Define.
-//!
-//! ## Interface
-//!
-//! ## Related Modules
-//!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -60,15 +45,10 @@ pub mod mock;
 mod tests;
 pub mod weights;
 
-use sp_runtime::traits::{Saturating, Zero};
 use sp_std::{prelude::*, vec};
 
-use frame_support::{
-	pallet_prelude::{ensure, DispatchError},
-	traits::{Currency, ReservableCurrency},
-};
-use frame_system::Config as SystemConfig;
-use webb_primitives::{hasher::*, types::DepositDetails};
+use frame_support::pallet_prelude::{ensure, DispatchError};
+use webb_primitives::hasher::*;
 
 pub use pallet::*;
 pub use weights::WeightInfo;

--- a/pallets/hasher/src/lib.rs
+++ b/pallets/hasher/src/lib.rs
@@ -45,10 +45,14 @@ pub mod mock;
 mod tests;
 pub mod weights;
 
+use frame_support::{
+	pallet_prelude::{ensure, DispatchError},
+	traits::{Currency, ReservableCurrency},
+};
+use frame_system::Config as SystemConfig;
+use sp_runtime::traits::{Saturating, Zero};
 use sp_std::{prelude::*, vec};
-
-use frame_support::pallet_prelude::{ensure, DispatchError};
-use webb_primitives::hasher::*;
+use webb_primitives::{hasher::*, types::DepositDetails};
 
 pub use pallet::*;
 pub use weights::WeightInfo;

--- a/pallets/linkable-tree/src/lib.rs
+++ b/pallets/linkable-tree/src/lib.rs
@@ -20,7 +20,7 @@
 //! A module for constructing, modifying and inspecting linkable trees.
 //!
 //! ## Overview
-//!	
+//!
 //! The Linkable-tree module provides functionality for the following:
 //!
 //! * Creating new linkable trees
@@ -38,29 +38,31 @@
 //! ### Goals
 //!
 //! The Linkable-tree in Webb is designed to make the following possible:
-//! 
+//!
 //! * Track state across EVM and Substrate chains
-//! *  
+//! *
 //!
 //! ## LinkableTreeInterface Interface
-//! 
+//!
 //! `create`: Creates a new linkable tree.
 //! `insert_in_order`: Inserts new leaf to the tree specified by provided id.
 //! `add_edge`: Adds an edge to tree specified by provided id.
 //! `update_edge`: Updates an edge to tree specified by provided id.
-//! 
+//!
 //! ## LinkableTreeInspector Interface
-//! 
+//!
 //! `get_chain_id`: Creates a new linkable tree.
 //! `is_known_root`: Checks if a merkle root is in a tree's cached history or returns.
 //! `ensure_known_root`: Ensure that passed root is in history.
 //! `get_root`: Gets the merkle root for a tree or returns `TreeDoesntExist`.
 //! `get_neighbor_roots`: Gets the merkle root for a tree or returns `TreeDoesntExist`.
-//! `is_known_neighbor_root`: Checks if a merkle root is in a tree's cached history or returns `TreeDoesntExist`.
-//! `ensure_known_neighbor_roots`: Checks if each root from passed root array is in tree's cached history or returns `InvalidNeighborWithdrawRoot`.
-//! `ensure_known_neighbor_root`: Checks if a merkle root is in a tree's cached history or returns `InvalidNeighborWithdrawRoot`.
+//! `is_known_neighbor_root`: Checks if a merkle root is in a tree's cached history or returns
+//! `TreeDoesntExist`. `ensure_known_neighbor_roots`: Checks if each root from passed root array is
+//! in tree's cached history or returns `InvalidNeighborWithdrawRoot`. `ensure_known_neighbor_root`:
+//! Checks if a merkle root is in a tree's cached history or returns `InvalidNeighborWithdrawRoot`.
 //! `has_edge`: Check if this linked tree has this edge.
-//! `ensure_max_edges`: Check if passed number of roots is the same as max allowed edges or returns `InvalidMerkleRoots`.
+//! `ensure_max_edges`: Check if passed number of roots is the same as max allowed edges or returns
+//! `InvalidMerkleRoots`.
 //!
 //! ## Related Implementations
 //!

--- a/pallets/linkable-tree/src/lib.rs
+++ b/pallets/linkable-tree/src/lib.rs
@@ -32,15 +32,15 @@
 //! The supported dispatchable functions are documented in the [`Call`] enum.
 //!
 //! ### Terminology
-//!  
-//! * **EdgeList**: A map of trees and chain ids to their edge metadata
+//!
+//! * **EdgeList**: A map of trees and chain ids to their edge metadata.
 //!  
 //! ### Goals
 //!
 //! The Linkable-tree in Webb is designed to make the following possible:
 //!
-//! * Track state across EVM and Substrate chains
-//! *
+//! * Store edges of neighboring anchors’ merkle roots
+//! * Store historoical data about neighboring merkle roots
 //!
 //! ## LinkableTreeInterface Interface
 //!
@@ -63,10 +63,6 @@
 //! `has_edge`: Check if this linked tree has this edge.
 //! `ensure_max_edges`: Check if passed number of roots is the same as max allowed edges or returns
 //! `InvalidMerkleRoots`.
-//!
-//! ## Related Implementations
-//!
-//! * [`LinkableTree.sol`](https://github.com/webb-tools/protocol-solidity/blob/main/contracts/anchors/LinkableTree.sol)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/linkable-tree/src/lib.rs
+++ b/pallets/linkable-tree/src/lib.rs
@@ -15,32 +15,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # Anchor Module
+//! # Linkable-tree Module
 //!
-//! A simple module for building Anchors.
+//! A module for constructing, modifying and inspecting linkable trees.
 //!
 //! ## Overview
+//!	
+//! The Linkable-tree module provides functionality for the following:
 //!
-//! The Anchor module provides functionality for the following:
-//!
-//! * Inserting elements to the tree
+//! * Creating new linkable trees
+//! * Inserting new leafs to a specified tree
+//! * Adding an edge to a specified tree
+//! * Updating an edge to a specified tree
+//! * Inspecting a tree's state
 //!
 //! The supported dispatchable functions are documented in the [`Call`] enum.
 //!
 //! ### Terminology
-//!
+//!  
+//! * **EdgeList**: A map of trees and chain ids to their edge metadata
+//!  
 //! ### Goals
 //!
-//! The Anchor system in Webb is designed to make the following possible:
+//! The Linkable-tree in Webb is designed to make the following possible:
+//! 
+//! * Track state across EVM and Substrate chains
+//! *  
 //!
-//! * Define.
+//! ## LinkableTreeInterface Interface
+//! 
+//! `create`: Creates a new linkable tree.
+//! `insert_in_order`: Inserts new leaf to the tree specified by provided id.
+//! `add_edge`: Adds an edge to tree specified by provided id.
+//! `update_edge`: Updates an edge to tree specified by provided id.
+//! 
+//! ## LinkableTreeInspector Interface
+//! 
+//! `get_chain_id`: Creates a new linkable tree.
+//! `is_known_root`: Checks if a merkle root is in a tree's cached history or returns.
+//! `ensure_known_root`: Ensure that passed root is in history.
+//! `get_root`: Gets the merkle root for a tree or returns `TreeDoesntExist`.
+//! `get_neighbor_roots`: Gets the merkle root for a tree or returns `TreeDoesntExist`.
+//! `is_known_neighbor_root`: Checks if a merkle root is in a tree's cached history or returns `TreeDoesntExist`.
+//! `ensure_known_neighbor_roots`: Checks if each root from passed root array is in tree's cached history or returns `InvalidNeighborWithdrawRoot`.
+//! `ensure_known_neighbor_root`: Checks if a merkle root is in a tree's cached history or returns `InvalidNeighborWithdrawRoot`.
+//! `has_edge`: Check if this linked tree has this edge.
+//! `ensure_max_edges`: Check if passed number of roots is the same as max allowed edges or returns `InvalidMerkleRoots`.
 //!
-//! ## Interface
+//! ## Related Implementations
 //!
-//! ## Related Modules
-//!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * [`LinkableTree.sol`](https://github.com/webb-tools/protocol-solidity/blob/main/contracts/anchors/LinkableTree.sol)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -17,26 +17,32 @@
 
 //! # Signature Bridge Module
 //!
-//! Add description #TODO
+//! A module for managing voting, resource, and maintainer composition through signature
+//! verification.
 //!
 //! ## Overview
 //!
+//! The signature bridge module provides functionalight for the following:
 //!
-//! ### Terminology
-//!
-//! ### Goals
-//!
-//! The signature bridge system in Webb is designed to make the following
-//! possible:
-//!
-//! * Define.
+//! * Private bridging of assets governed by signature verification
 //!
 //! ## Interface
 //!
-//! ## Related Modules
+//! ### Permissioned Functions
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * `force_set_maintainer`: Forcefully set the maintainer. This method requires the `origin` to be
+//!   [T::AdminOrigin].
+//! * `set_resource`: Stores a method name on chain under an associated resource ID. This method
+//!   requires the `origin` to be [T::AdminOrigin].
+//! * `remove_resource`: Removes a resource ID from the resource mapping. This method requires the
+//!   `origin` to be [T::AdminOrigin].
+//! * `whitelist_chain`: Enables a chain ID as a source or destination for a bridge transfer. This
+//!   method requires the `origin` to be [T::AdminOrigin].
+//!
+//! ### Permissionless Functions
+//!
+//! * `execute_proposal`: Commits a vote in favour of the provided proposal.
+//! * `set_maintainer`: Sets the maintainer.
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -175,7 +181,7 @@ pub mod pallet {
 			new_maintainer: Vec<u8>,
 			signature: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			let origin = ensure_signed(origin)?;
+			let _origin = ensure_signed(origin)?;
 			let old_maintainer = <Maintainer<T, I>>::get();
 			// ensure parameter setter is the maintainer
 			ensure!(

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -181,7 +181,7 @@ pub mod pallet {
 			new_maintainer: Vec<u8>,
 			signature: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			let _origin = ensure_signed(origin)?;
+			let origin = ensure_signed(origin)?;
 			let old_maintainer = <Maintainer<T, I>>::get();
 			// ensure parameter setter is the maintainer
 			ensure!(

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Overview
 //!
-//! The signature bridge module provides functionalight for the following:
+//! The signature bridge module provides functionality for the following:
 //!
 //! * Private bridging of assets governed by signature verification
 //!

--- a/pallets/token-wrapper-handler/src/lib.rs
+++ b/pallets/token-wrapper-handler/src/lib.rs
@@ -40,11 +40,9 @@
 //! ## Interface
 //!
 //! ## Related Modules
+//!
 //! * Token-Wrapper Pallet
 //! * Bridge Pallet
-//!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/vanchor/src/lib.rs
+++ b/pallets/vanchor/src/lib.rs
@@ -29,20 +29,13 @@
 //!
 //! The supported dispatchable functions are documented in the [`Call`] enum.
 //!
-//! ### Terminology
-//!
-//! ### Goals
-//!
-//! The VAnchor system in Webb is designed to make the following possible:
-//!
-//! * Define.
-//!
 //! ## Interface
 //!
-//! ## Related Modules
+//! ### Permissionless Functions
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * `create`: Creates an vanchor and inserts an element into the on-chain merkle tree.
+//! * `transact`: Allows the withdrawel of variable asset sizes but requires a zero-knowledge proof
+//!   of an unspent (UTXO) in an anchors merkle tree specified by TreeId.
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/pallets/xanchor/src/lib.rs
+++ b/pallets/xanchor/src/lib.rs
@@ -17,26 +17,55 @@
 
 //! # xAnchor Module
 //!
-//! Add description #TODO
+//! A module for managing the linking process between anchors.
 //!
 //! ## Overview
 //!
+//! The xanchor module provides functionality for:
 //!
-//! ### Terminology
-//!
-//! ### Goals
-//!
-//! The xAnchor system in Webb is designed to make the following
-//! possible:
-//!
-//! * Define.
+//! * Linking additional anchors from other chains.
+//! * Updates anchors upon sucessfully requested link.
+//! * Signaling the success of the linking process back to the other chain that requested the link.
 //!
 //! ## Interface
 //!
+//! ### Permissionless Functions
+//!
+//! * `propose_to_link_anchor`: Creates a new Proposal to link two anchors cross-chain by creating
+//!   on-chain proposal that once passed will send to the other chain a link proposal.
+//! * `handle_link_anchor_message`: Handles the Link anchor proposal from other chain, by creating
+//!   an on-chain proposal that once passed will link the anchors on the local chain, also signals
+//!   back the caller chain with the proposal hash, so the caller chain know that the link process
+//!   is complete.
+//! * `sync_anchors`: Sync All the Anchors in this chain to the other chains that are already
+//!   linked.
+//!
+//! ### Permissioned Functions
+//!
+//! * `send_link_anchor_message`: Once a proposal is passed, this function will send a Link proposal
+//!   to the other chain also, save the proposal hash locally so when the other chain passes the
+//!   proposal, we get signled back with the proposal hash and we link the anchors. This method
+//!   requires the `origin` to be [T::DemocracyOrigin].
+//! * `save_link_proposal`: Stores Proposal to link two anchors cross-chain. This method requires
+//!   the `origin` to be a sibling parachain.
+//! * `link_anchors`: Links chain locally, and signal back to the other chain that requested the
+//!   link that the link process is completed. This method requires the `origin` to be
+//!   [T::DemocracyOrigin].
+//! * `handle_link_anchors`: Handles the signal back from the other parachain, if the link process
+//!   is there is done to complete the link process here too. This method requires the `origin` to
+//!   be a sibling parachain.
+//! * `register_resource_id`: Registers this [ResourceId] to an anchor which exists on the other
+//!   chain. Only could be called by [T::DemocracyOrigin].
+//! * `force_register_resource_id`: A Forced version of [Self::register_resource_id] which can be
+//!   only called by the Root.
+//! * `update`: Updates the anchor. This method requires the `origin` to be a sibling parachain.
+//! * `force_update`: A Forced version of [Self::update] which can be only called by the Root.
+//!
 //! ## Related Modules
 //!
-//! * [`System`](../frame_system/index.html)
-//! * [`Support`](../frame_support/index.html)
+//! * Anchor Pallet
+//! * Linkable-tree Pallet
+//! * MT pallet
 
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
**Changes introduced in this pr:**

**NOTE:** Please provide suggestions for improved descriptions, definitions and language used. Especially for `signature-bridge` as I feel a better description of the pallet can be used.

- Adds pallet documentation for [linkable-tree](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/linkable-tree/src/lib.rs)
- Adds pallet documentation for [bridge](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/bridge/src/lib.rs)
- Adds pallet documentation for [anchor-handler](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/anchor-handler/src/lib.rs)
- Adds pallet documentation for [anchor](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/anchor/src/lib.rs)
- Adds pallet documentation for [signature-bridge](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/signature-bridge/src/lib.rs)
- Adds pallet documentation for [xanchor](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/xanchor/src/lib.rs)
- Updates pallet documentation for [vanchor](https://github.com/webb-tools/protocol-substrate/blob/main/pallets/vanchor/src/lib.rs)