### PR TITLE
chore: removed unused, dead, and deprecated code

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,24 +1,18 @@
-use ark_bn254::Bn254;
-use arkworks_utils::{
-	poseidon::PoseidonParameters,
-	utils::common::{setup_params_x5_3, setup_params_x5_5, Curve},
-};
+use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
 use common::{AccountId, AuraId, Signature};
 use darkwebb_runtime::{
-	wasm_binary_unwrap, AssetRegistryConfig, AuraConfig, BalancesConfig, CouncilConfig,
-	GenesisConfig, HasherBls381Config, HasherBn254Config, MerkleTreeBls381Config,
-	MerkleTreeBn254Config, MixerBn254Config, ParachainStakingConfig, SudoConfig, SystemConfig,
-	VerifierBls381Config, VerifierBn254Config, KUNITS, UNITS,
+	wasm_binary_unwrap, AssetRegistryConfig, CouncilConfig, GenesisConfig, HasherBls381Config,
+	HasherBn254Config, MerkleTreeBls381Config, MerkleTreeBn254Config, MixerBn254Config,
+	ParachainStakingConfig, SudoConfig, VerifierBls381Config, VerifierBn254Config, KUNITS, UNITS,
 };
 use webb_primitives::Balance;
 
 use cumulus_primitives_core::ParaId;
-use hex_literal::hex;
 use pallet_parachain_staking::{InflationInfo, Range};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
-use sp_core::{crypto::UncheckedInto, sr25519, Pair, Public};
+use sp_core::{sr25519, Pair, Public};
 use sp_runtime::{
 	traits::{IdentifyAccount, Verify},
 	Perbill, Percent,
@@ -26,10 +20,6 @@ use sp_runtime::{
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec = sc_service::GenericChainSpec<darkwebb_runtime::GenesisConfig, Extensions>;
-
-/// Specialized `ChainSpec` for the normal parachain runtime.
-pub type DarkwebbChainSpec =
-	sc_service::GenericChainSpec<darkwebb_runtime::GenesisConfig, Extensions>;
 
 /// Specialized `ChainSpec` for the shell parachain runtime.
 pub type ShellChainSpec = sc_service::GenericChainSpec<shell_runtime::GenesisConfig, Extensions>;
@@ -264,8 +254,6 @@ fn testnet_genesis(
 
 	log::info!("Verifier params");
 	let verifier_params = {
-		use std::fs;
-		// let pk_bytes = fs::read("../../fixtures/proving_key.bin").unwrap();
 		let vk_bytes =
 			include_bytes!("../../protocol-substrate-fixtures/mixer/bn254/x5/verifying_key.bin");
 

--- a/pallets/anchor-handler/src/lib.rs
+++ b/pallets/anchor-handler/src/lib.rs
@@ -55,7 +55,6 @@ use frame_support::{dispatch::DispatchResultWithPostInfo, ensure, traits::Ensure
 use frame_system::pallet_prelude::OriginFor;
 use pallet_anchor::{BalanceOf, CurrencyIdOf};
 use pallet_linkable_tree::types::EdgeMetadata;
-use sp_std::prelude::*;
 use webb_primitives::{
 	anchor::AnchorConfig,
 	traits::anchor::{AnchorInspector, AnchorInterface},

--- a/pallets/asset-registry/src/lib.rs
+++ b/pallets/asset-registry/src/lib.rs
@@ -44,7 +44,6 @@ pub use pallet::*;
 
 use crate::types::{AssetDetails, AssetMetadata};
 use frame_support::BoundedVec;
-use sp_runtime::traits::Zero;
 pub use traits::{Registry, ShareTokenRegistry};
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/hasher/src/lib.rs
+++ b/pallets/hasher/src/lib.rs
@@ -60,15 +60,10 @@ pub mod mock;
 mod tests;
 pub mod weights;
 
-use sp_runtime::traits::{Saturating, Zero};
 use sp_std::{prelude::*, vec};
 
-use frame_support::{
-	pallet_prelude::{ensure, DispatchError},
-	traits::{Currency, ReservableCurrency},
-};
-use frame_system::Config as SystemConfig;
-use webb_primitives::{hasher::*, types::DepositDetails};
+use frame_support::pallet_prelude::{ensure, DispatchError};
+use webb_primitives::hasher::*;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -129,7 +124,6 @@ pub mod pallet {
 		StorageValue<_, Vec<u8>, ValueQuery>;
 
 	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {}
 
 	#[pallet::error]

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -175,7 +175,7 @@ pub mod pallet {
 			new_maintainer: Vec<u8>,
 			signature: Vec<u8>,
 		) -> DispatchResultWithPostInfo {
-			let origin = ensure_signed(origin)?;
+			let _origin = ensure_signed(origin)?;
 			let old_maintainer = <Maintainer<T, I>>::get();
 			// ensure parameter setter is the maintainer
 			ensure!(

--- a/pallets/token-wrapper-handler/src/lib.rs
+++ b/pallets/token-wrapper-handler/src/lib.rs
@@ -59,7 +59,7 @@ pub mod mock_signature_bridge;
 #[cfg(test)]
 mod tests_signature_bridge;
 
-use frame_support::{dispatch::DispatchResultWithPostInfo, ensure, traits::EnsureOrigin};
+use frame_support::traits::EnsureOrigin;
 use frame_system::pallet_prelude::OriginFor;
 
 ///TODO: Define BalanceOf
@@ -91,7 +91,6 @@ pub mod pallet {
 	pub struct Pallet<T>(_);
 
 	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		UpdatedWrappingFeePercent { wrapping_fee_percent: BalanceOf<T> },
 	}
@@ -115,7 +114,8 @@ pub mod pallet {
 		#[pallet::weight(195_000_000)]
 		pub fn execute_wrapping_fee_proposal(
 			origin: OriginFor<T>,
-			r_id: ResourceId,
+			// TODO: param not being used
+			_r_id: ResourceId,
 			wrapping_fee_percent: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			// TODO: Define and check validity conditions.
@@ -127,7 +127,8 @@ pub mod pallet {
 		#[pallet::weight(195_000_000)]
 		pub fn execute_add_token_to_pool_share(
 			origin: OriginFor<T>,
-			r_id: ResourceId,
+			// TODO: param is not used
+			_r_id: ResourceId,
 			name: Vec<u8>,
 			asset_id: T::AssetId,
 		) -> DispatchResultWithPostInfo {
@@ -140,7 +141,8 @@ pub mod pallet {
 		#[pallet::weight(195_000_000)]
 		pub fn execute_remove_token_from_pool_share(
 			origin: OriginFor<T>,
-			r_id: ResourceId,
+			// TODO: param not being used
+			_r_id: ResourceId,
 			name: Vec<u8>,
 			asset_id: T::AssetId,
 		) -> DispatchResultWithPostInfo {

--- a/pallets/vanchor/src/lib.rs
+++ b/pallets/vanchor/src/lib.rs
@@ -278,7 +278,7 @@ pub mod pallet {
 			max_deposit_amount: BalanceOf<T, I>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			<Self as VAnchorInterface<_>>::set_max_deposit_amount(max_deposit_amount);
+			<Self as VAnchorInterface<_>>::set_max_deposit_amount(max_deposit_amount)?;
 			Ok(().into())
 		}
 
@@ -288,7 +288,7 @@ pub mod pallet {
 			min_withdraw_amount: BalanceOf<T, I>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			<Self as VAnchorInterface<_>>::set_min_withdraw_amount(min_withdraw_amount);
+			<Self as VAnchorInterface<_>>::set_min_withdraw_amount(min_withdraw_amount)?;
 			Ok(().into())
 		}
 
@@ -298,7 +298,7 @@ pub mod pallet {
 			max_ext_amount: BalanceOf<T, I>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			<Self as VAnchorInterface<_>>::set_max_ext_amount(max_ext_amount);
+			<Self as VAnchorInterface<_>>::set_max_ext_amount(max_ext_amount)?;
 			Ok(().into())
 		}
 
@@ -308,7 +308,7 @@ pub mod pallet {
 			max_fee: BalanceOf<T, I>,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			<Self as VAnchorInterface<_>>::set_max_fee(max_fee);
+			<Self as VAnchorInterface<_>>::set_max_fee(max_fee)?;
 			Ok(().into())
 		}
 	}

--- a/pallets/verifier/src/lib.rs
+++ b/pallets/verifier/src/lib.rs
@@ -62,16 +62,10 @@ mod tests;
 mod benchmarking;
 
 pub mod weights;
-use sp_runtime::traits::{Saturating, Zero};
 use sp_std::prelude::*;
 
-use codec::Encode;
-use frame_support::{
-	pallet_prelude::{ensure, DispatchError},
-	traits::{Currency, ReservableCurrency},
-};
-use frame_system::Config as SystemConfig;
-use webb_primitives::{types::DepositDetails, verifier::*};
+use frame_support::pallet_prelude::{ensure, DispatchError};
+use webb_primitives::verifier::*;
 
 pub use pallet::*;
 pub use weights::WeightInfo;
@@ -132,7 +126,6 @@ pub mod pallet {
 		StorageValue<_, Vec<u8>, ValueQuery>;
 
 	#[pallet::event]
-	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {}
 
 	#[pallet::error]

--- a/primitives/src/signing/ecdsa.rs
+++ b/primitives/src/signing/ecdsa.rs
@@ -2,7 +2,6 @@ pub use sp_io::{hashing::keccak_256, EcdsaVerifyError};
 use sp_std::vec::Vec;
 
 pub const SIGNATURE_LENGTH: usize = 65;
-const KEY_LENGTH: usize = 32;
 
 pub fn validate_ecdsa_signature(data: &[u8], signature: &[u8]) -> bool {
 	if signature.len() == SIGNATURE_LENGTH {

--- a/primitives/src/signing/mod.rs
+++ b/primitives/src/signing/mod.rs
@@ -1,4 +1,3 @@
-use codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 pub mod ecdsa;

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -76,7 +76,7 @@ pub mod fee {
 }
 
 pub mod time {
-	use common::{BlockNumber, Moment};
+	use common::BlockNumber;
 
 	/// This determines the average expected block time that we are targeting.
 	/// Blocks will be produced at a minimum duration defined by

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -36,9 +36,9 @@ use sp_core::{
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT},
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, Perbill, Percent, Permill,
+	ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -1122,7 +1122,7 @@ pub type Executive = frame_executive::Executive<
 	Block,
 	frame_system::ChainContext<Runtime>,
 	Runtime,
-	AllPallets,
+	AllPalletsWithoutSystemReversed,
 	OnRuntimeUpgrade,
 >;
 

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -1,6 +1,4 @@
-use arkworks_utils::utils::common::{
-	setup_params_x3_5, setup_params_x5_3, setup_params_x5_5, Curve,
-};
+use arkworks_utils::utils::common::{setup_params_x5_3, Curve};
 use common::{AccountId, BabeId, Balance, Signature};
 
 use darkwebb_runtime::{

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1402,7 +1402,7 @@ pub type Executive = frame_executive::Executive<
 	Block,
 	frame_system::ChainContext<Runtime>,
 	Runtime,
-	AllPallets,
+	AllPalletsWithoutSystemReversed,
 	OnRuntimeUpgrade,
 >;
 


### PR DESCRIPTION
# Overview

- Removed unused imports, variables, dead and deprecated code

**Note:** Changes from `AllPallets` to `AllPalletsWithoutSystemReversed` were made based off [#10043](https://github.com/paritytech/substrate/pull/10043). I defaulted to use `AllPalletsWithoutSystemReversed` but closer inspection would be good.
