### PR TITLE
fix ordering of function sig and nonce

### DIFF
--- a/pallets/anchor-handler/src/tests_signature_bridge.rs
+++ b/pallets/anchor-handler/src/tests_signature_bridge.rs
@@ -69,8 +69,8 @@ fn make_anchor_update_proposal(
 
 fn make_proposal_data(encoded_r_id: Vec<u8>, nonce: [u8; 4], encoded_call: Vec<u8>) -> Vec<u8> {
 	let mut prop_data = encoded_r_id;
-	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&[0u8; 4]);
+	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&encoded_call[..]);
 	prop_data
 }

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -378,7 +378,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	}
 
 	pub fn parse_nonce_from_proposal_data(proposal_data: &Vec<u8>) -> T::ProposalNonce {
-		let nonce_bytes = proposal_data[32..36].try_into().unwrap_or_default();
+		let nonce_bytes = proposal_data[36..40].try_into().unwrap_or_default();
 		let nonce = u32::from_be_bytes(nonce_bytes);
 		T::ProposalNonce::from(nonce)
 	}

--- a/pallets/signature-bridge/src/tests.rs
+++ b/pallets/signature-bridge/src/tests.rs
@@ -84,8 +84,8 @@ fn make_proposal(r: Vec<u8>) -> mock::Call {
 
 fn make_proposal_data(encoded_r_id: Vec<u8>, nonce: [u8; 4], encoded_call: Vec<u8>) -> Vec<u8> {
 	let mut prop_data = encoded_r_id;
-	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&[0u8; 4]);
+	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&encoded_call[..]);
 	prop_data
 }

--- a/pallets/token-wrapper-handler/src/tests_signature_bridge.rs
+++ b/pallets/token-wrapper-handler/src/tests_signature_bridge.rs
@@ -73,8 +73,8 @@ fn make_remove_token_proposal(resource_id: &[u8; 32], name: Vec<u8>, asset_id: u
 
 fn make_proposal_data(encoded_r_id: Vec<u8>, nonce: [u8; 4], encoded_call: Vec<u8>) -> Vec<u8> {
 	let mut prop_data = encoded_r_id;
-	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&[0u8; 4]);
+	prop_data.extend_from_slice(&nonce);
 	prop_data.extend_from_slice(&encoded_call[..]);
 	prop_data
 }


### PR DESCRIPTION
I accidentally mixed up the ordering between the function sig (zeroes padding) and nonce in the proposal data.

This is a small PR to correct it.