### PR TITLE
Update "protocol-substrate-fixtures" submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "protocol-substrate-fixtures"]
 	path = protocol-substrate-fixtures
 	url = https://github.com/webb-tools/protocol-substrate-fixtures.git
-	branch = main
+	branch = bn254_x5_3_16-2-vanchor

--- a/client/tests/integration_tests.rs
+++ b/client/tests/integration_tests.rs
@@ -136,10 +136,10 @@ async fn test_anchor() -> Result<(), Box<dyn std::error::Error>> {
 	);
 
 	let pk_bytes = include_bytes!(
-		"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/proving_key_uncompressed.bin"
+		"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/proving_key_uncompressed.bin"
 	);
 	let vk_bytes = include_bytes!(
-		"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/verifying_key_uncompressed.bin"
+		"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/verifying_key_uncompressed.bin"
 	);
 	let recipient = AccountKeyring::Bob.to_account_id();
 	let relayer = AccountKeyring::Bob.to_account_id();
@@ -326,10 +326,10 @@ async fn test_vanchor() -> Result<(), Box<dyn std::error::Error>> {
 	);
 
 	let pk_bytes = include_bytes!(
-		"../../protocol-substrate-fixtures/vanchor/bn254/x5/proving_key_uncompressed.bin"
+		"../../protocol-substrate-fixtures/vanchor/bn254/x5/2-2-2/proving_key_uncompressed.bin"
 	);
 	let vk_bytes = include_bytes!(
-		"../../protocol-substrate-fixtures/vanchor/bn254/x5/verifying_key_uncompressed.bin"
+		"../../protocol-substrate-fixtures/vanchor/bn254/x5/2-2-2/verifying_key_uncompressed.bin"
 	);
 
 	let params4 = setup_params::<Bn254Fr>(Curve::Bn254, 5, 4);

--- a/pallets/anchor/src/tests.rs
+++ b/pallets/anchor/src/tests.rs
@@ -44,10 +44,10 @@ fn setup_environment(curve: Curve) -> Vec<u8> {
 			// 3. Setup the VerifierPallet
 			//    but to do so, we need to have a VerifyingKey
 			let pk_bytes = include_bytes!(
-				"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/proving_key_uncompressed.bin"
+				"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/proving_key_uncompressed.bin"
 			);
 			let vk_bytes = include_bytes!(
-				"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/verifying_key.bin"
+				"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/verifying_key.bin"
 			);
 
 			assert_ok!(VerifierPallet::force_set_parameters(Origin::root(), vk_bytes.to_vec()));

--- a/pallets/vanchor/src/tests.rs
+++ b/pallets/vanchor/src/tests.rs
@@ -44,11 +44,11 @@ fn setup_environment() -> (Vec<u8>, Vec<u8>) {
 	//    but to do so, we need to have a VerifyingKey
 
 	let pk_bytes = include_bytes!(
-		"../../../protocol-substrate-fixtures/vanchor/bn254/x5/proving_key_uncompressed.bin"
+		"../../../protocol-substrate-fixtures/vanchor/bn254/x5/2-2-2/proving_key_uncompressed.bin"
 	)
 	.to_vec();
 	let vk_bytes =
-		include_bytes!("../../../protocol-substrate-fixtures/vanchor/bn254/x5/verifying_key.bin")
+		include_bytes!("../../../protocol-substrate-fixtures/vanchor/bn254/x5/2-2-2/verifying_key.bin")
 			.to_vec();
 
 	assert_ok!(VerifierPallet::force_set_parameters(Origin::root(), vk_bytes.clone()));

--- a/pallets/xanchor/src/tests.rs
+++ b/pallets/xanchor/src/tests.rs
@@ -31,12 +31,12 @@ fn setup_environment(curve: Curve) -> Vec<u8> {
 			//    but to do so, we need to have a VerifyingKey
 			let (pk_bytes, vk_bytes) = (
 				std::fs::read(
-					"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/proving_key.bin",
+					"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/proving_key.bin",
 				)
 				.expect("Unable to read file")
 				.to_vec(),
 				std::fs::read(
-					"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/verifying_key.bin",
+					"../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/verifying_key.bin",
 				)
 				.expect("Unable to read file")
 				.to_vec(),

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -208,7 +208,7 @@ fn testnet_genesis(
 	log::info!("Verifier params for anchor");
 	let anchor_verifier_bn254_params = {
 		let vk_bytes = include_bytes!(
-			"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/verifying_key.bin"
+			"../../../protocol-substrate-fixtures/fixed-anchor/bn254/x5/2/verifying_key.bin"
 		);
 		vk_bytes.to_vec()
 	};
@@ -216,7 +216,7 @@ fn testnet_genesis(
 	log::info!("Verifier params for vanchor");
 	let vanchor_verifier_bn254_params = {
 		let vk_bytes = include_bytes!(
-			"../../../protocol-substrate-fixtures/vanchor/bn254/x5/verifying_key.bin"
+			"../../../protocol-substrate-fixtures/vanchor/bn254/x5/2-2-2/verifying_key.bin"
 		);
 		vk_bytes.to_vec()
 	};


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update the "protocol-substrate-fixtures" submodule path 
- Update the paths of zk-setup keys(prove & verify) files in whole codebase.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #179 
