### PR TITLE
Update edge metadata with target/system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10817,10 +10817,11 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bd361a7bbeb70489139c7a34a41d23b26190f29aab5c94bcee30685992687"
+checksum = "2680384f7b2701caf6cfc51e14d671fe5615dee4306940a356c05f757a005dbe"
 dependencies = [
+ "num-traits",
  "parity-scale-codec 2.3.1",
  "scale-info 1.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,6 +5664,7 @@ dependencies = [
  "sp-runtime 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.17)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.17)",
  "webb-primitives",
+ "webb-proposals",
  "xcm",
  "xcm-builder",
  "xcm-executor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10818,9 +10818,9 @@ dependencies = [
 
 [[package]]
 name = "webb-proposals"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2680384f7b2701caf6cfc51e14d671fe5615dee4306940a356c05f757a005dbe"
+checksum = "989a673b719232a23f49327db2f2d816f5241ad4ad6b54cc6e45e896bd3c3e5b"
 dependencies = [
  "num-traits",
  "parity-scale-codec 2.3.1",

--- a/client/tests/utils.rs
+++ b/client/tests/utils.rs
@@ -48,7 +48,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/anchor-handler/src/lib.rs
+++ b/pallets/anchor-handler/src/lib.rs
@@ -210,14 +210,18 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 	) -> DispatchResultWithPostInfo {
 		let tree_id =
 			AnchorList::<T, I>::try_get(r_id).map_err(|_| Error::<T, I>::AnchorHandlerNotFound)?;
-		let (src_chain_id, merkle_root, block_height) =
-			(anchor_metadata.src_chain_id, anchor_metadata.root, anchor_metadata.latest_leaf_index);
+		let (src_chain_id, merkle_root, latest_leaf_index, target) = (
+			anchor_metadata.src_chain_id,
+			anchor_metadata.root,
+			anchor_metadata.latest_leaf_index,
+			anchor_metadata.target,
+		);
 
 		if T::Anchor::has_edge(tree_id, src_chain_id) {
-			T::Anchor::update_edge(tree_id, src_chain_id, merkle_root, block_height)?;
+			T::Anchor::update_edge(tree_id, src_chain_id, merkle_root, latest_leaf_index, target)?;
 			Self::deposit_event(Event::AnchorEdgeUpdated);
 		} else {
-			T::Anchor::add_edge(tree_id, src_chain_id, merkle_root, block_height)?;
+			T::Anchor::add_edge(tree_id, src_chain_id, merkle_root, latest_leaf_index, target)?;
 			Self::deposit_event(Event::AnchorEdgeAdded);
 		}
 		let nonce = Counts::<T, I>::try_get(src_chain_id)

--- a/pallets/anchor-handler/src/mock_bridge.rs
+++ b/pallets/anchor-handler/src/mock_bridge.rs
@@ -167,7 +167,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/anchor-handler/src/mock_signature_bridge.rs
+++ b/pallets/anchor-handler/src/mock_signature_bridge.rs
@@ -167,7 +167,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/anchor-handler/src/tests_bridge.rs
+++ b/pallets/anchor-handler/src/tests_bridge.rs
@@ -168,7 +168,9 @@ fn anchor_update_proposal_edge_add_success() {
 		mock_anchor_creation_using_pallet_call(src_chain_id, &resource_id);
 		let root = Element::from_bytes(&[1; 32]);
 		let latest_leaf_index = 5;
-		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index };
+		let expected_tree_id = 0u32;
+		let target = Element::from_bytes(&expected_tree_id.to_le_bytes());
+		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index, target };
 		assert_eq!(0, Counts::<Test>::get(src_chain_id));
 		relay_anchor_update_proposal(src_chain_id, &resource_id, prop_id, edge_metadata.clone());
 		assert_eq!(1, Counts::<Test>::get(src_chain_id));
@@ -215,7 +217,9 @@ fn anchor_update_proposal_edge_update_success() {
 		mock_anchor_creation_using_pallet_call(src_chain_id, &resource_id);
 		let root = Element::from_bytes(&[1; 32]);
 		let latest_leaf_index = 5;
-		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index };
+		let expected_tree_id = 0u32;
+		let target = Element::from_bytes(&expected_tree_id.to_le_bytes());
+		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index, target };
 		assert_eq!(0, Counts::<Test>::get(src_chain_id));
 		relay_anchor_update_proposal(src_chain_id, &resource_id, prop_id, edge_metadata.clone());
 		assert_eq!(1, Counts::<Test>::get(src_chain_id));
@@ -242,7 +246,7 @@ fn anchor_update_proposal_edge_update_success() {
 
 		let root = Element::from_bytes(&[2; 32]);
 		let latest_leaf_index = 10;
-		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index };
+		let edge_metadata = EdgeMetadata { src_chain_id, root, latest_leaf_index, target };
 		relay_anchor_update_proposal(
 			src_chain_id,
 			&resource_id,

--- a/pallets/anchor-handler/src/tests_signature_bridge.rs
+++ b/pallets/anchor-handler/src/tests_signature_bridge.rs
@@ -158,7 +158,9 @@ hex!("8db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd913ebbe148dd
 
 			let root = Element::from_bytes(&[1; 32]);
 			let latest_leaf_index = 5;
-			let edge_metadata = EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index };
+			let target = Element::from_bytes(&[0u8; 32]);
+			let edge_metadata =
+				EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index, target };
 			assert_eq!(0, Counts::<Test>::get(src_id));
 
 			let anchor_update_call = make_anchor_update_proposal(&r_id, edge_metadata.clone());
@@ -233,7 +235,9 @@ hex!("8db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd913ebbe148dd
 
 			let root = Element::from_bytes(&[1; 32]);
 			let latest_leaf_index = 5;
-			let edge_metadata = EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index };
+			let target = Element::from_bytes(&[0u8; 32]);
+			let edge_metadata =
+				EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index, target };
 			assert_eq!(0, Counts::<Test>::get(src_id));
 
 			let anchor_update_call = make_anchor_update_proposal(&r_id, edge_metadata.clone());
@@ -282,7 +286,9 @@ hex!("8db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd913ebbe148dd
 			// Update Edge
 			let root = Element::from_bytes(&[2; 32]);
 			let latest_leaf_index = 10;
-			let edge_metadata = EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index };
+			let target = Element::from_bytes(&[0u8; 32]);
+			let edge_metadata =
+				EdgeMetadata { src_chain_id: src_id, root, latest_leaf_index, target };
 
 			let anchor_update_call = make_anchor_update_proposal(&r_id, edge_metadata.clone());
 			let anchor_update_call_encoded = anchor_update_call.encode();

--- a/pallets/anchor/src/lib.rs
+++ b/pallets/anchor/src/lib.rs
@@ -464,8 +464,9 @@ impl<T: Config<I>, I: 'static> AnchorInterface<AnchorConfigration<T, I>> for Pal
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
-		T::LinkableTree::add_edge(id, src_chain_id, root, latest_leaf_index)
+		T::LinkableTree::add_edge(id, src_chain_id, root, latest_leaf_index, target)
 	}
 
 	fn update_edge(
@@ -473,8 +474,9 @@ impl<T: Config<I>, I: 'static> AnchorInterface<AnchorConfigration<T, I>> for Pal
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
-		T::LinkableTree::update_edge(id, src_chain_id, root, latest_leaf_index)
+		T::LinkableTree::update_edge(id, src_chain_id, root, latest_leaf_index, target)
 	}
 }
 

--- a/pallets/anchor/src/mock.rs
+++ b/pallets/anchor/src/mock.rs
@@ -165,7 +165,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/linkable-tree/src/lib.rs
+++ b/pallets/linkable-tree/src/lib.rs
@@ -251,6 +251,7 @@ impl<T: Config<I>, I: 'static> LinkableTreeInterface<LinkableTreeConfigration<T,
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
 		// ensure edge doesn't exists
 		ensure!(
@@ -262,7 +263,7 @@ impl<T: Config<I>, I: 'static> LinkableTreeInterface<LinkableTreeConfigration<T,
 		let curr_length = EdgeList::<T, I>::iter_prefix_values(id).into_iter().count();
 		ensure!(max_edges > curr_length as u32, Error::<T, I>::TooManyEdges);
 		// craft edge
-		let e_meta = EdgeMetadata { src_chain_id, root, latest_leaf_index };
+		let e_meta = EdgeMetadata { src_chain_id, root, latest_leaf_index, target };
 		// update historical neighbor list for this edge's root
 		let neighbor_root_inx = CurrentNeighborRootIndex::<T, I>::get((id, src_chain_id));
 		CurrentNeighborRootIndex::<T, I>::insert(
@@ -280,9 +281,10 @@ impl<T: Config<I>, I: 'static> LinkableTreeInterface<LinkableTreeConfigration<T,
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
 		ensure!(EdgeList::<T, I>::contains_key(id, src_chain_id), Error::<T, I>::EdgeDoesntExists);
-		let e_meta = EdgeMetadata { src_chain_id, root, latest_leaf_index };
+		let e_meta = EdgeMetadata { src_chain_id, root, latest_leaf_index, target };
 		let neighbor_root_inx = (CurrentNeighborRootIndex::<T, I>::get((id, src_chain_id)) +
 			T::RootIndex::one()) %
 			T::HistoryLength::get();

--- a/pallets/linkable-tree/src/mock.rs
+++ b/pallets/linkable-tree/src/mock.rs
@@ -147,7 +147,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/linkable-tree/src/tests.rs
+++ b/pallets/linkable-tree/src/tests.rs
@@ -52,11 +52,13 @@ fn should_be_able_to_add_neighbors_and_check_history() {
 		let height = 1;
 		let neighbor_index_before: u32 =
 			LinkableTree::curr_neighbor_root_index((tree_id, src_chain_id));
+		let target = Element::from_bytes(&tree_id.to_le_bytes());
 		assert_ok!(<LinkableTree as LinkableTreeInterface<_>>::add_edge(
 			tree_id,
 			src_chain_id,
 			root,
 			height,
+			target,
 		));
 		let neighbor_index_after: u32 =
 			LinkableTree::curr_neighbor_root_index((tree_id, src_chain_id));
@@ -67,11 +69,13 @@ fn should_be_able_to_add_neighbors_and_check_history() {
 
 			let val = thread_rng().gen::<[u8; 32]>();
 			let elt = Element::from_bytes(&val);
+			let target = Element::from_bytes(&tree_id.to_le_bytes());
 			assert_ok!(<LinkableTree as LinkableTreeInterface<_>>::update_edge(
 				tree_id,
 				src_chain_id,
 				elt,
 				height,
+				target
 			));
 
 			assert!(LinkableTree::is_known_neighbor_root(tree_id, src_chain_id, elt).unwrap(),);

--- a/pallets/linkable-tree/src/types.rs
+++ b/pallets/linkable-tree/src/types.rs
@@ -11,4 +11,6 @@ pub struct EdgeMetadata<ChainID, Element, LastLeafIndex> {
 	pub root: Element,
 	/// height of source chain anchor's native merkle tree
 	pub latest_leaf_index: LastLeafIndex,
+	/// Target contract address or tree identifier
+	pub target: Element,
 }

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -144,7 +144,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/mt/src/mock.rs
+++ b/pallets/mt/src/mock.rs
@@ -132,7 +132,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/vanchor/src/lib.rs
+++ b/pallets/vanchor/src/lib.rs
@@ -495,8 +495,9 @@ impl<T: Config<I>, I: 'static> VAnchorInterface<VAnchorConfigration<T, I>> for P
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
-		T::LinkableTree::add_edge(id, src_chain_id, root, latest_leaf_index)
+		T::LinkableTree::add_edge(id, src_chain_id, root, latest_leaf_index, target)
 	}
 
 	fn update_edge(
@@ -504,8 +505,9 @@ impl<T: Config<I>, I: 'static> VAnchorInterface<VAnchorConfigration<T, I>> for P
 		src_chain_id: T::ChainId,
 		root: T::Element,
 		latest_leaf_index: T::LeafIndex,
+		target: T::Element,
 	) -> Result<(), DispatchError> {
-		T::LinkableTree::update_edge(id, src_chain_id, root, latest_leaf_index)
+		T::LinkableTree::update_edge(id, src_chain_id, root, latest_leaf_index, target)
 	}
 
 	fn set_max_deposit_amount(max_deposit_amount: BalanceOf<T, I>) -> Result<(), DispatchError> {

--- a/pallets/vanchor/src/mock.rs
+++ b/pallets/vanchor/src/mock.rs
@@ -166,7 +166,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/xanchor/Cargo.toml
+++ b/pallets/xanchor/Cargo.toml
@@ -22,6 +22,7 @@ pallet-anchor = { path = "../anchor", default-features = false }
 orml-traits = { path = "../../open-runtime-module-library/traits", default-features = false }
 webb-primitives = { path = "../../primitives", default-features = false }
 pallet-asset-registry = { path = "../asset-registry", default-features = false }
+webb-proposals = { version = "0.2.3", default-features = false }
 
 # XCM dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.17", default-features = false }
@@ -82,6 +83,7 @@ std = [
 	"webb-primitives/std",
 	"pallet-asset-registry/std",
 	"frame-benchmarking/std",
+	"webb-proposals/std",
 ]
 
 runtime-benchmarks = [

--- a/pallets/xanchor/Cargo.toml
+++ b/pallets/xanchor/Cargo.toml
@@ -22,7 +22,7 @@ pallet-anchor = { path = "../anchor", default-features = false }
 orml-traits = { path = "../../open-runtime-module-library/traits", default-features = false }
 webb-primitives = { path = "../../primitives", default-features = false }
 pallet-asset-registry = { path = "../asset-registry", default-features = false }
-webb-proposals = { version = "0.2.3", default-features = false }
+webb-proposals = { version = "0.2.4", default-features = false }
 
 # XCM dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.17", default-features = false }

--- a/pallets/xanchor/src/lib.rs
+++ b/pallets/xanchor/src/lib.rs
@@ -524,6 +524,7 @@ pub mod pallet {
 				//src_chain_id: my
 				root: ElementOf::<T, I>::from_bytes(anchor_update_proposal.merkle_root()),
 				latest_leaf_index: anchor_update_proposal.latest_leaf_index().into(),
+				target: ElementOf::<T, I>::from_bytes(&tree_id.encode()),
 			};
 
 			// and finally, ensure that the anchor exists
@@ -602,6 +603,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				metadata.src_chain_id,
 				metadata.root,
 				metadata.latest_leaf_index,
+				metadata.target,
 			)?;
 
 			Self::deposit_event(Event::AnchorEdgeAdded);
@@ -612,6 +614,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				metadata.src_chain_id,
 				metadata.root,
 				metadata.latest_leaf_index,
+				metadata.target,
 			)?;
 
 			Self::deposit_event(Event::AnchorEdgeAdded);

--- a/pallets/xanchor/src/lib.rs
+++ b/pallets/xanchor/src/lib.rs
@@ -493,7 +493,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn update(
 			origin: OriginFor<T>,
-			anchor_update_proposal_bytes: [u8; 82],
+			anchor_update_proposal_bytes: [u8; 114],
 		) -> DispatchResultWithPostInfo {
 			ensure_sibling_para(<T as Config<I>>::Origin::from(origin))?;
 
@@ -644,6 +644,9 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		let root = tree.root;
 		// and the latest leaf index
 		let latest_leaf_index = tree.leaf_count;
+		// and the target system
+		let target_system =
+			webb_proposals::TargetSystem::new_tree_id(tree_id.try_into().unwrap_or_default());
 		// get the current parachain id
 		let my_para_id = T::ParaId::get();
 		let src_chain_id = u32::from(my_para_id);
@@ -690,6 +693,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 				typed_src_chain_id,
 				latest_leaf_index_u32,
 				merkle_root,
+				target_system.into_fixed_bytes(),
 			);
 
 			let other_para_id = chain_id_to_para_id::<T, I>(other_chain_id);

--- a/pallets/xanchor/src/mock/parachain.rs
+++ b/pallets/xanchor/src/mock/parachain.rs
@@ -402,7 +402,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/pallets/xanchor/src/tests.rs
+++ b/pallets/xanchor/src/tests.rs
@@ -373,7 +373,7 @@ fn ensure_that_the_only_way_to_update_edges_is_from_another_parachain() {
 		let proposal_header = ProposalHeader::new(r_id, function_signature, nonce);
 		let typed_chain_id = TypedChainId::Substrate(PARAID_B.into());
 
-		let mut merkle_root = [0; 32];
+		let merkle_root = [0; 32];
 
 		let anchor_update_proposal = AnchorUpdateProposal::new(
 			proposal_header,

--- a/pallets/xanchor/src/tests.rs
+++ b/pallets/xanchor/src/tests.rs
@@ -363,6 +363,7 @@ fn ensure_that_the_only_way_to_update_edges_is_from_another_parachain() {
 		// try to update the edges, from a normal account!
 		// it should fail.
 		let tree_id = MerkleTree::next_tree_id();
+		let target_system = webb_proposals::TargetSystem::new_tree_id(tree_id);
 		let r_id = derive_resource_id(PARAID_B.into(), tree_id).into();
 
 		let function_signature = FunctionSignature::new([0; 4]);
@@ -379,6 +380,7 @@ fn ensure_that_the_only_way_to_update_edges_is_from_another_parachain() {
 			typed_chain_id,
 			latest_leaf_index_u32,
 			merkle_root,
+			target_system.into_fixed_bytes(),
 		);
 
 		assert_err!(
@@ -808,7 +810,10 @@ fn should_fail_to_call_update_as_signed_account() {
 	// calling update as signed account should fail.
 	// on parachain A.
 	ParaA::execute_with(|| {
-		let r_id = derive_resource_id(PARAID_B.into(), MerkleTree::next_tree_id()).into();
+		let tree_id = MerkleTree::next_tree_id();
+		let target_system =
+			webb_proposals::TargetSystem::new_tree_id(tree_id.try_into().unwrap_or_default());
+		let r_id = derive_resource_id(PARAID_B.into(), tree_id).into();
 		/*let edge_metadata = EdgeMetadata {
 			src_chain_id: PARAID_B.into(),
 			root: Element::zero(),
@@ -829,6 +834,7 @@ fn should_fail_to_call_update_as_signed_account() {
 			typed_chain_id,
 			latest_leaf_index_u32,
 			merkle_root,
+			target_system.into_fixed_bytes(),
 		);
 
 		assert_err!(

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -37,7 +37,7 @@ codec = { default-features = false, features = ["derive", "max-encoded-len"], pa
 ethabi = { version = "15.0.0", default-features = false }
 hex-literal = { version = "0.3.4", default-features = false }
 
-webb-proposals = { version = "0.2.1", default-features = false }
+webb-proposals = { version = "0.2.3", default-features = false }
 
 [features]
 default = ["std", "hashing", "verifying", "field_ops"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -37,7 +37,7 @@ codec = { default-features = false, features = ["derive", "max-encoded-len"], pa
 ethabi = { version = "15.0.0", default-features = false }
 hex-literal = { version = "0.3.4", default-features = false }
 
-webb-proposals = { version = "0.2.3", default-features = false }
+webb-proposals = { version = "0.2.4", default-features = false }
 
 [features]
 default = ["std", "hashing", "verifying", "field_ops"]

--- a/primitives/src/traits/anchor.rs
+++ b/primitives/src/traits/anchor.rs
@@ -52,6 +52,7 @@ pub trait AnchorInterface<C: AnchorConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		latest_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 	/// Update an edge for this tree
 	fn update_edge(
@@ -59,6 +60,7 @@ pub trait AnchorInterface<C: AnchorConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		latest_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 }
 

--- a/primitives/src/traits/linkable_tree.rs
+++ b/primitives/src/traits/linkable_tree.rs
@@ -29,6 +29,7 @@ pub trait LinkableTreeInterface<C: LinkableTreeConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		last_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 	/// Update an edge for this tree
 	fn update_edge(
@@ -36,6 +37,7 @@ pub trait LinkableTreeInterface<C: LinkableTreeConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		last_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 }
 

--- a/primitives/src/traits/vanchor.rs
+++ b/primitives/src/traits/vanchor.rs
@@ -41,6 +41,7 @@ pub trait VAnchorInterface<C: VAnchorConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		latest_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 	/// Update an edge for this tree
 	fn update_edge(
@@ -48,6 +49,7 @@ pub trait VAnchorInterface<C: VAnchorConfig> {
 		src_chain_id: C::ChainId,
 		root: C::Element,
 		latest_leaf_index: C::LeafIndex,
+		target: C::Element,
 	) -> Result<(), dispatch::DispatchError>;
 
 	fn set_max_deposit_amount(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -715,7 +715,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1076,7 +1076,13 @@ impl ElementTrait for Element {
 
 	fn from_bytes(input: &[u8]) -> Self {
 		let mut buf = [0u8; 32];
-		buf.copy_from_slice(input);
+		let input_length = input.len();
+		if input_length > 32 {
+			buf.copy_from_slice(input);
+		} else {
+			buf[0..input_length].copy_from_slice(input);
+		};
+
 		Self(buf)
 	}
 }


### PR DESCRIPTION
# Overview
This PR updates the anchor update metadata proposals with the target system as a 32-byte value. This change is primarily geared with saving even more information about edges so that end-user applications can rely on less external configuration. This is done by adding the contract addresses / tree ids we're bridging

## Related:
- [webb-rs](https://github.com/webb-tools/webb-rs/pull/31)
- [relayer](https://github.com/webb-tools/relayer/pull/165)
- [protocol-solidity](https://github.com/webb-tools/protocol-solidity/pull/142/)
