### PR TITLE
Fix max edges in chain_spec

### DIFF
--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -334,7 +334,7 @@ fn testnet_genesis(
 			],
 		},
 		anchor_bn_254: AnchorBn254Config {
-			anchors: vec![(0, 10 * UNITS, 2), (0, 100 * UNITS, 2), (0, 1000 * UNITS, 2)],
+			anchors: vec![(0, 10 * UNITS, 1), (0, 100 * UNITS, 1), (0, 1000 * UNITS, 1)],
 		},
 		v_anchor_bn_254: VAnchorBn254Config {
 			max_deposit_amount: 1_000_000 * UNITS,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixes max edges in chain spec for anchors (should be 1 max edge for a total of 2 anchors on a bridge)


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
