### PR TITLE
Make `AssetNativeLocation` of type `u32`

### DIFF
--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1174,7 +1174,7 @@ impl pallet_verifier::Config<pallet_verifier::Instance3> for Runtime {
 
 impl pallet_asset_registry::Config for Runtime {
 	type AssetId = webb_primitives::AssetId;
-	type AssetNativeLocation = ();
+	type AssetNativeLocation = u32;
 	type Balance = Balance;
 	type Event = Event;
 	type NativeAssetId = GetNativeCurrencyId;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- change `AssetNativeLocation` type from `()` to `u32`.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
As a workaround to https://github.com/paritytech/subxt/issues/552 
we will revert these changes once this upstream bug is resolved.
