### PR TITLE
[fix] Webb-primitives : use serde derive

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.119", optional = true }
+serde = { version = "1.0.119", optional = true, features = ["derive"] }
 codec = { default-features = false, features = ["derive", "max-encoded-len"], package = "parity-scale-codec", version = "3" }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use `derive` feature to prevent error when importing in other repos
