### PR TITLE
Decode Dispatchable call directly from proposal bytes

### DIFF
--- a/pallets/signature-bridge/src/mock.rs
+++ b/pallets/signature-bridge/src/mock.rs
@@ -96,8 +96,14 @@ impl Contains<Call> for SetResourceProposalFilter {
 
 pub struct ExecuteAllProposalsFilter;
 impl Contains<Call> for ExecuteAllProposalsFilter {
-	fn contains(_c: &Call) -> bool {
-		true
+	fn contains(c: &Call) -> bool {
+		match c {
+			Call::System(method) => match method {
+				system::Call::remark { .. } => true,
+				_ => false,
+			},	
+			_ => false,
+		}
 	}
 }
 

--- a/pallets/signature-bridge/src/mock.rs
+++ b/pallets/signature-bridge/src/mock.rs
@@ -101,7 +101,7 @@ impl Contains<Call> for ExecuteAllProposalsFilter {
 			Call::System(method) => match method {
 				system::Call::remark { .. } => true,
 				_ => false,
-			},	
+			},
 			_ => false,
 		}
 	}

--- a/pallets/signature-bridge/src/tests.rs
+++ b/pallets/signature-bridge/src/tests.rs
@@ -68,7 +68,6 @@ fn create_proposal_tests() {
 			Bridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(call.clone()),
 				prop_data.clone(),
 				sig.0.to_vec(),
 			),
@@ -81,7 +80,6 @@ fn create_proposal_tests() {
 		assert_ok!(Bridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(call.clone()),
 			prop_data.clone(),
 			sig.0.to_vec(),
 		));
@@ -187,7 +185,6 @@ fn should_fail_to_set_resource_id_when_nonce_increments_by_more_than_1048() {
 			Bridge::set_resource_with_signature(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(call.clone()),
 				prop_data.clone(),
 				sig.0.to_vec(),
 			),

--- a/pallets/signature-bridge/src/tests.rs
+++ b/pallets/signature-bridge/src/tests.rs
@@ -245,7 +245,7 @@ fn should_fail_on_invalid_proposal_call() {
 
 		// set the new maintainer
 		assert_ok!(Bridge::force_set_maintainer(Origin::root(), public_uncompressed.to_vec()));
-		
+
 		// should fail to execute proposal as invalid call is provided
 		assert_err!(
 			Bridge::execute_proposal(

--- a/pallets/signature-bridge/src/tests.rs
+++ b/pallets/signature-bridge/src/tests.rs
@@ -221,3 +221,40 @@ fn set_maintainer_should_work() {
 		assert_ok!(Bridge::set_maintainer(Origin::signed(RELAYER_A), message, sig.encode()));
 	})
 }
+
+#[test]
+fn should_fail_on_invalid_proposal_call() {
+	let chain_type = [2, 0];
+	let src_id = compute_chain_id_type(1u32, chain_type);
+	let r_id =
+		derive_resource_id(1080u32, SubstrateTargetSystem { pallet_index: 2, tree_id: 1 }).into();
+	let public_uncompressed = hex!("8db55b05db86c0b1786ca49f095d76344c9e6056b2f02701a7e7f3c20aabfd913ebbe148dd17c56551a52952371071a6c604b3f3abe8f2c8fa742158ea6dd7d4");
+	let pair = ecdsa::Pair::from_string(
+		"0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+		None,
+	)
+	.unwrap();
+
+	new_test_ext_initialized(src_id, r_id, b"System.remark".to_vec()).execute_with(|| {
+		let call = Call::Balances(pallet_balances::Call::transfer { dest: 1, value: 1 });
+		let call_encoded = call.encode();
+		let nonce = [0u8, 0u8, 0u8, 1u8];
+		let prop_data = make_proposal_data(r_id.encode(), nonce, call_encoded);
+		let msg = keccak_256(&prop_data);
+		let sig: Signature = pair.sign_prehashed(&msg).into();
+
+		// set the new maintainer
+		assert_ok!(Bridge::force_set_maintainer(Origin::root(), public_uncompressed.to_vec()));
+		
+		// should fail to execute proposal as invalid call is provided
+		assert_err!(
+			Bridge::execute_proposal(
+				Origin::signed(RELAYER_A),
+				src_id,
+				prop_data.clone(),
+				sig.0.to_vec(),
+			),
+			Error::<Test>::InvalidCall
+		);
+	})
+}

--- a/pallets/token-wrapper-handler/src/tests_signature_bridge.rs
+++ b/pallets/token-wrapper-handler/src/tests_signature_bridge.rs
@@ -5,7 +5,7 @@ use sp_core::{
 	keccak_256, Pair,
 };
 
-use super::mock_signature_bridge::{Call, Origin, SignatureBridge, Test, RELAYER_A};
+use super::mock_signature_bridge::{Origin, SignatureBridge, Test, RELAYER_A};
 
 use crate::mock_signature_bridge::new_test_ext_initialized;
 
@@ -121,14 +121,12 @@ fn should_update_fee_with_sig_succeed() {
 		let wrapping_fee_proposal_bytes = make_wrapping_fee_proposal(header, 5, pool_share_id);
 		let msg = keccak_256(&wrapping_fee_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
-		let fee_call: Call =
-			codec::Decode::decode(&mut &wrapping_fee_proposal_bytes[40..]).unwrap();
+
 		// should fail to execute proposal as non-maintainer
 		assert_err!(
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(fee_call.clone()),
 				wrapping_fee_proposal_bytes.clone(),
 				sig.0.to_vec(),
 			),
@@ -144,7 +142,6 @@ fn should_update_fee_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(fee_call.clone()),
 			wrapping_fee_proposal_bytes.clone(),
 			sig.0.to_vec(),
 		));
@@ -196,14 +193,10 @@ fn should_add_token_with_sig_succeed() {
 			Origin::root(),
 			public_uncompressed.to_vec()
 		));
-
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
 		// Create proposal (& vote)
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -261,13 +254,10 @@ fn should_remove_token_with_sig_succeed() {
 			public_uncompressed.to_vec()
 		));
 
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
 		// Create proposal (& vote)
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -280,13 +270,9 @@ fn should_remove_token_with_sig_succeed() {
 		let msg = keccak_256(&remove_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
-		let remove_token_call: Call =
-			codec::Decode::decode(&mut &remove_token_proposal_bytes[40..]).unwrap();
-
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(remove_token_call.clone()),
 			remove_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -338,13 +324,11 @@ fn should_fail_to_remove_token_not_in_pool_with_sig() {
 			make_remove_token_proposal(header, "meme".to_string(), first_token_id);
 		let msg = keccak_256(&remove_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
-		let remove_token_call: Call =
-			codec::Decode::decode(&mut &remove_token_proposal_bytes[40..]).unwrap();
+
 		assert_err!(
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(remove_token_call.clone()),
 				remove_token_proposal_bytes,
 				sig.0.to_vec(),
 			),
@@ -407,15 +391,13 @@ fn should_add_many_tokens_with_sig_succeed() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), first_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 		// Create proposal (& vote)
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -423,8 +405,7 @@ fn should_add_many_tokens_with_sig_succeed() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), second_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
@@ -432,7 +413,6 @@ fn should_add_many_tokens_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -440,8 +420,7 @@ fn should_add_many_tokens_with_sig_succeed() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), third_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
@@ -449,7 +428,6 @@ fn should_add_many_tokens_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes,
 			sig.0.to_vec(),
 		));
@@ -500,8 +478,7 @@ fn should_fail_to_add_same_token_with_sig() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), first_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
@@ -514,7 +491,6 @@ fn should_fail_to_add_same_token_with_sig() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id,
-			Box::new(add_token_call.clone()),
 			add_token_proposal_bytes.clone(),
 			sig.0.to_vec(),
 		));
@@ -526,8 +502,7 @@ fn should_fail_to_add_same_token_with_sig() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), first_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
@@ -535,7 +510,6 @@ fn should_fail_to_add_same_token_with_sig() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(add_token_call.clone()),
 				add_token_proposal_bytes.clone(),
 				sig.0.to_vec(),
 			),
@@ -579,8 +553,7 @@ fn should_fail_to_add_non_existent_token_with_sig() {
 		let header = make_proposal_header(r_id, ADD_TOKEN_FUNCTION_SIG, nonce);
 		let add_token_proposal_bytes =
 			make_add_token_proposal(header, "meme".to_string(), first_token_id);
-		let add_token_call: Call =
-			codec::Decode::decode(&mut &add_token_proposal_bytes[40..]).unwrap();
+
 		let msg = keccak_256(&add_token_proposal_bytes);
 		let sig: Signature = pair.sign_prehashed(&msg).into();
 
@@ -594,7 +567,6 @@ fn should_fail_to_add_non_existent_token_with_sig() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id,
-				Box::new(add_token_call.clone()),
 				add_token_proposal_bytes.clone(),
 				sig.0.to_vec(),
 			),

--- a/pallets/vanchor-handler/src/tests_signature_bridge.rs
+++ b/pallets/vanchor-handler/src/tests_signature_bridge.rs
@@ -147,7 +147,6 @@ fn should_create_vanchor_with_sig_succeed() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id.chain_id(),
-				Box::new(anchor_create_call.clone()),
 				prop_data.clone(),
 				sig.0.to_vec(),
 			),
@@ -163,7 +162,6 @@ fn should_create_vanchor_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id.chain_id(),
-			Box::new(anchor_create_call.clone()),
 			prop_data.clone(),
 			sig.0.to_vec(),
 		));
@@ -223,7 +221,6 @@ fn should_add_vanchor_edge_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id.chain_id(),
-			Box::new(anchor_update_call.clone()),
 			prop_data,
 			sig.0.to_vec(),
 		));
@@ -303,7 +300,6 @@ fn should_update_vanchor_edge_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id.chain_id(),
-			Box::new(anchor_update_call.clone()),
 			prop_data,
 			sig.0.to_vec(),
 		));
@@ -349,7 +345,6 @@ fn should_update_vanchor_edge_with_sig_succeed() {
 		assert_ok!(SignatureBridge::execute_proposal(
 			Origin::signed(RELAYER_A),
 			src_id.chain_id(),
-			Box::new(anchor_update_call.clone()),
 			prop_data,
 			sig.0.to_vec(),
 		));
@@ -435,7 +430,6 @@ fn should_fail_to_execute_proposal_from_non_whitelisted_chain() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id.chain_id() + 1,
-				Box::new(anchor_create_call.clone()),
 				prop_data,
 				sig.0.to_vec(),
 			),
@@ -490,7 +484,6 @@ fn should_fail_to_execute_proposal_with_non_existent_resource_id() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id.chain_id(),
-				Box::new(anchor_create_call.clone()),
 				prop_data,
 				sig.0.to_vec(),
 			),
@@ -543,7 +536,6 @@ fn should_fail_to_verify_proposal_with_tampered_signature() {
 			SignatureBridge::execute_proposal(
 				Origin::signed(RELAYER_A),
 				src_id.chain_id(),
-				Box::new(anchor_create_call.clone()),
 				prop_data,
 				tampered_sig.clone(),
 			),
@@ -587,12 +579,10 @@ fn should_add_resource_sig_succeed_using_webb_proposals() {
 			Origin::root(),
 			public_uncompressed.to_vec()
 		));
-		let set_resource_call: Call =
-			codec::Decode::decode(&mut &set_resource_proposal_bytes[40..]).unwrap();
+
 		assert_ok!(SignatureBridge::set_resource_with_signature(
 			Origin::signed(RELAYER_A),
 			src_id.chain_id(),
-			Box::new(set_resource_call),
 			set_resource_proposal_bytes,
 			sig.0.to_vec(),
 		));


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
Instead of passing the dispatchable call to `execute_proposal` and `set_resource_with_signature` we can directly decode the call from proposal bytes and then apply a `Call` filter check.

Since the relayer will be using a dynamic query, it is a bit difficult to construct the required Call configuration as input so decided to remove it.  For more detail [link](https://github.com/paritytech/subxt/issues/682)

```rust
// Decode executable call
let proposal_call = codec::Decode::decode(&mut parsed_call.as_slice())
           .map_err(|_| Error::<T, I>::InvalidCall)?;
// Ensure decoded call exists in Call filter.
ensure!(T::ExecuteProposalFilter::contains(&proposal_call), Error::<T, I>::InvalidCall);
```

- [x] Decode call directly from proposal bytes in   `execute_proposal` and `set_resource_with_signature`
- [x]  Update tests


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
