### PR TITLE
Deocde nonce from be bytes

### DIFF
--- a/pallets/signature-bridge/src/benchmarking.rs
+++ b/pallets/signature-bridge/src/benchmarking.rs
@@ -45,7 +45,7 @@ pub fn generate_maintainer_signatures<T: Config<I>, I: 'static>() -> (Vec<u8>, V
 	let old_maintainer = ecdsa_generate(DUMMY, None);
 	let old_maintainer_key = set_maintainer_on_chain::<T, I>(old_maintainer);
 	let mut message = vec![];
-	let nonce = 1u32.encode();
+	let nonce = 1u32.to_be_bytes;
 	message.extend_from_slice(&nonce);
 	message.extend_from_slice(&new_maintainer.encode());
 	let hash = keccak_256(&message);

--- a/pallets/signature-bridge/src/lib.rs
+++ b/pallets/signature-bridge/src/lib.rs
@@ -266,9 +266,9 @@ pub mod pallet {
 			let maintainer_nonce = MaintainerNonce::<T, I>::get();
 			let nonce = maintainer_nonce + 1u32.into();
 			// nonce should be the first 4 bytes of this message
-			let nonce_from_maintainer = T::MaintainerNonce::decode(&mut &message[..4])
-				.map_err(|_| Error::<T, I>::InvalidNonce)?;
-
+			let mut nonce_bytes = [0u8; 4];
+			nonce_bytes[0..4].copy_from_slice(&message[..4]);
+			let nonce_from_maintainer: T::MaintainerNonce = u32::from_be_bytes(nonce_bytes).into();
 			// Nonce should increment by 1
 			ensure!(nonce_from_maintainer == nonce, Error::<T, I>::InvalidNonce);
 

--- a/pallets/signature-bridge/src/tests.rs
+++ b/pallets/signature-bridge/src/tests.rs
@@ -218,7 +218,7 @@ fn set_maintainer_should_work() {
 			old_maintainer.try_into().unwrap();
 		Maintainer::<Test, _>::put(bounded_old_maintainer);
 		let mut message = vec![];
-		let nonce = 1u32.encode();
+		let nonce = 1u32.to_be_bytes();
 		message.extend_from_slice(&nonce);
 		message.extend_from_slice(&new_maintainer);
 		let msg = keccak_256(&message);


### PR DESCRIPTION
## Summary of changes

-  Decoder from `parity_scale_codec` expects nonce to be decoded from `le_bytes`, whereas dkg signs a message in which nonce is converted to `be_bytes`.
```rust
let nonce_from_maintainer = T::MaintainerNonce::decode(&mut &message[..4])
.map_err(|_| Error::<T, I>::InvalidNonce)?;
```
Therefore, we need to decode nonce directly using `from_be_bytes`
```
let mut nonce_bytes = [0u8; 4];
nonce_bytes[0..4].copy_from_slice(&message[..4]);
let nonce_from_maintainer: T::MaintainerNonce = u32::from_be_bytes(nonce_bytes).into();
```


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
