### PR TITLE
[chore] Set properties when starting a local testnet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,9 @@
 [submodule "substrate-fixtures"]
 	path = substrate-fixtures
 	url = https://github.com/webb-tools/substrate-fixtures
+	branch = main
 
 [submodule "solidity-fixtures"]
 	path = solidity-fixtures
 	url = https://github.com/webb-tools/solidity-fixtures
-
+	branch = main

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -2,7 +2,7 @@ use arkworks_setups::{common::setup_params, Curve};
 use webb_primitives::{types::runtime::BabeId, AccountId, Balance, Signature};
 
 use itertools::Itertools;
-use sc_chain_spec::ChainSpecExtension;
+use sc_chain_spec::{ChainSpecExtension, Properties};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
 use sp_core::{sr25519, Pair, Public};
@@ -84,11 +84,15 @@ fn webb_session_keys(
 	webb_runtime::SessionKeys { grandpa, babe, im_online, authority_discovery }
 }
 
-pub fn webb_development_config() -> Result<ChainSpec, String> {
-	let mut properties = sc_chain_spec::Properties::new();
+fn properties() -> Properties {
+	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "Unit".into());
 	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
+	properties
+}
+
+pub fn webb_development_config() -> Result<ChainSpec, String> {
 	Ok(ChainSpec::from_genesis(
 		// Name
 		"Development",
@@ -130,7 +134,7 @@ pub fn webb_development_config() -> Result<ChainSpec, String> {
 		// Fork ID
 		None,
 		// Properties
-		Some(properties),
+		Some(properties()),
 		Default::default(),
 	))
 }
@@ -177,7 +181,7 @@ pub fn webb_local_testnet_config() -> Result<ChainSpec, String> {
 		// Fork ID
 		None,
 		// Properties
-		None,
+		Some(properties()),
 		// Extensions
 		Default::default(),
 	))


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- I wasnt getting any properties in relayer tests, because it starts the substrate node with local testnet config. So this config should also set the same properties. 


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Required for https://github.com/webb-tools/relayer/pull/375
