### PR TITLE
[fix] do not transfer wrapping fee if less than ED

### DIFF
--- a/pallets/token-wrapper/src/lib.rs
+++ b/pallets/token-wrapper/src/lib.rs
@@ -451,6 +451,12 @@ impl<T: Config> TokenWrapperInterface<T::AccountId, T::AssetId, BalanceOf<T>, T:
 					&Self::get_fee_recipient(&asset_details.name),
 					Self::get_wrapping_fee(amount, into_pool_share_id)?,
 				)?;
+			} else {
+				T::Currency::withdraw(
+					from_currency_id,
+					&from,
+					Self::get_wrapping_fee(amount, into_pool_share_id)?,
+				)?;
 			}
 		} else {
 			T::Currency::transfer(

--- a/pallets/token-wrapper/src/mock.rs
+++ b/pallets/token-wrapper/src/mock.rs
@@ -19,6 +19,8 @@ type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 type BlockNumber = u64;
 
+pub const EXISTENSIAL_DEPOSIT: u64 = 1;
+
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -98,7 +100,7 @@ impl asset_registry::Config for Test {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u64 = 1;
+	pub const ExistentialDeposit: u64 = EXISTENSIAL_DEPOSIT;
 }
 
 impl pallet_balances::Config for Test {

--- a/pallets/token-wrapper/src/tests.rs
+++ b/pallets/token-wrapper/src/tests.rs
@@ -128,6 +128,7 @@ fn token_wrap_should_not_fail_when_fee_less_than_ed() {
 		// increment nonce
 		let nonce = nonce + 1;
 		assert_ok!(TokenWrapper::set_wrapping_fee(RuntimeOrigin::root(), 1, pool_share_id, nonce));
+		let initial_balance_first_token = TokenWrapper::get_balance(first_token_id, &recipient);
 
 		// here we wrap 50, the fee recipient receives 1% which is equal to 10
 		// this is less than ED but should not fail
@@ -143,6 +144,12 @@ fn token_wrap_should_not_fail_when_fee_less_than_ed() {
 		assert!(wrapping_fee < existential_balance.into());
 		// the fee recipient does not receive any fee since the account does not have ED
 		assert_eq!(TokenWrapper::get_balance(first_token_id, &fee_recipient), 0);
+
+		assert_eq!(
+			TokenWrapper::get_balance(first_token_id, &recipient),
+			initial_balance_first_token
+				.saturating_sub(TokenWrapper::get_amount_to_wrap(1000_u128, pool_share_id))
+		);
 
 		// deposit some ED to the fee recipient account
 		assert_ok!(Currencies::update_balance(


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- There can be cases where the wrapping fee is less than the ED for an asset. In these cases, we do not transfer the fees to the recipient but instead burn the fees.

Other approaches considered:
- Creating a storageMap with the record of all the fees to be paid out, this does not solve the problem but instead we need to ensure that the interim account that holds the fees (until the recipient withdraws, most likely the pallet-account) needs to have the ED.
- If the amount is less than ED, burn the fee amount, add to storage and later mint to the fee_recipient in a function `claim_all_fees`. This messes up with the total_supply calculation. 

In any approach we take an amount less than ED cannot be transferred unless the recipient already has ED, this is not a question of the account existing but rather blocked by pallet_balances/pallet_orml_tokens.

**Reference issue to close (if applicable)**
Closes #326 
